### PR TITLE
fix(Readme): WTFPL tautology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Not-for-iPhone USB-C Mod
 
-The content of this repository is licensed under the [WTFPL License](http://www.wtfpl.net/). Please have a close look at the terms before using this material.
+The content of this repository is licensed under the [WTFPL](http://www.wtfpl.net/). Please have a close look at the terms of the license before using this material.
 
 Nothing in this repository is part of Apple's Intellectual Property. Any resemblance to actual products or registered trademarks is entirely coincidental.
 


### PR DESCRIPTION
Fixes: #9 

As the fix of the tautology may be disadvantageous to the readability of the readme, I added a little part in the second sentence to make the character of the mentioned WTFPL more clear.